### PR TITLE
Remove traceback

### DIFF
--- a/generate_failover_imports
+++ b/generate_failover_imports
@@ -1,15 +1,11 @@
 #!/usr/bin/env python
 
-import sys
-
 infile = sys.argv[1]
 outfile = sys.argv[2]
 
 with open(infile) as fin:
     with open(outfile, 'w') as fout:
         for line in fin:
-            fout.write('try:\n')
+            fout.write('from contextlib import suppress\n')
+            fout.write('with suppress(ImportError, ModuleNotFoundError):\n')
             fout.write('    ' + line)
-            fout.write('except ImportError as err:\n')
-            fout.write('    print(err)\n')
-

--- a/generate_failover_imports
+++ b/generate_failover_imports
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
+import sys
 
 infile = sys.argv[1]
 outfile = sys.argv[2]
 
 with open(infile) as fin:
     with open(outfile, 'w') as fout:
+        fout.write('from contextlib import suppress\n')
         for line in fin:
-            fout.write('from contextlib import suppress\n')
             fout.write('with suppress(ImportError, ModuleNotFoundError):\n')
             fout.write('    ' + line)

--- a/install
+++ b/install
@@ -4,6 +4,7 @@ import os
 import sys
 import shutil
 import subprocess as sp
+from contextlib import suppress
 
 rundir = os.path.dirname(os.path.abspath('__file__'))
 config_file = os.path.join(rundir, 'ipython_config.py')
@@ -18,7 +19,8 @@ startup_dir = os.path.join(profile_dir, 'startup')
 shutil.copy(config_file, profile_dir)
 # Then, generate the custom imports file
 sp.call([os.path.join(rundir, 'generate_failover_imports'),
-         import_file, output_file])
+        import_file, output_file])
+
 # Finally, copy the failover imports to the startup dir
 shutil.copy(output_file, startup_dir)
 # .. and delete the local copy

--- a/install
+++ b/install
@@ -19,7 +19,7 @@ startup_dir = os.path.join(profile_dir, 'startup')
 shutil.copy(config_file, profile_dir)
 # Then, generate the custom imports file
 sp.call([os.path.join(rundir, 'generate_failover_imports'),
-        import_file, output_file])
+         import_file, output_file])
 
 # Finally, copy the failover imports to the startup dir
 shutil.copy(output_file, startup_dir)

--- a/ipython_config.py
+++ b/ipython_config.py
@@ -3,8 +3,6 @@
 import os
 import datetime as dt
 import sys
-from contextlib import suppress
-
 
 c = get_config()
 
@@ -92,9 +90,15 @@ c.TerminalIPythonApp.display_banner = False
 
 # Start IPython quickly by skipping the loading of config files.
 # c.TerminalIPythonApp.quick = False
-c.InteractiveShellApp.extensions = []
+
+
 
 # A list of dotted module names of IPython extensions to load.
+
+c.InteractiveShellApp.extensions = []
+
+# Including these custom imports inside a try and catch block has the effect of
+# suppressing the stacktrace appearing in stdout if there are import errors.
 try:
     import line_profiler
     c.InteractiveShellApp.extensions.append('line_profiler')

--- a/ipython_config.py
+++ b/ipython_config.py
@@ -2,6 +2,9 @@
 
 import os
 import datetime as dt
+import sys
+from contextlib import suppress
+
 
 c = get_config()
 
@@ -10,10 +13,10 @@ c = get_config()
 #------------------------------------------------------------------------------
 
 # A Mixin for applications that start InteractiveShell instances.
-# 
+#
 # Provides configurables for loading extensions and executing files as part of
 # configuring a Shell environment.
-# 
+#
 # Provides init_extensions() and init_code() methods, to be called after
 # init_shell(), which must be implemented by subclasses.
 
@@ -62,7 +65,7 @@ c = get_config()
 
 # Pre-load matplotlib and numpy for interactive use, selecting a particular
 # matplotlib backend and loop integration.
-# c.TerminalIPythonApp.pylab = None
+# c.TerminalIPythonApp.pylab = 'qt5'
 
 # Suppress warning messages about legacy config files
 # hilariously, this setting now itself causes a warning!
@@ -89,12 +92,20 @@ c.TerminalIPythonApp.display_banner = False
 
 # Start IPython quickly by skipping the loading of config files.
 # c.TerminalIPythonApp.quick = False
+c.InteractiveShellApp.extensions = []
 
 # A list of dotted module names of IPython extensions to load.
-c.InteractiveShellApp.extensions = [
-    'line_profiler',
-    'cython'
-]
+try:
+    import line_profiler
+    c.InteractiveShellApp.extensions.append('line_profiler')
+except ImportError as err:
+    print('line_profiler not installed.', file=sys.stderr)
+try:
+    import cython
+    c.InteractiveShellApp.extensions.append('cython')
+except ImportError as err:
+    print('cython not installed.', file=sys.stderr)
+
 
 # Whether to install the default config files into the profile dir. If a new
 # profile is being created, and IPython contains config files for that profile,
@@ -128,7 +139,7 @@ c.InteractiveShellApp.extensions = [
 # color codes, this capability can be turned off.
 # c.TerminalInteractiveShell.color_info = True
 
-# 
+#
 # c.TerminalInteractiveShell.history_length = 10000
 
 # Don't call post-execute functions that have failed in the past.
@@ -143,13 +154,13 @@ c.InteractiveShellApp.extensions = [
 # Autoindent IPython code entered interactively.
 # c.TerminalInteractiveShell.autoindent = True
 
-# 
+#
 # c.TerminalInteractiveShell.separate_in = '\n'
 
 # Deprecated, use PromptManager.in2_template
 # c.TerminalInteractiveShell.prompt_in2 = '   .\\D.: '
 
-# 
+#
 # c.TerminalInteractiveShell.separate_out = ''
 
 # Deprecated, use PromptManager.in_template
@@ -190,19 +201,19 @@ c.InteractiveShellApp.extensions = [
 # The part of the banner to be printed before the profile
 # c.TerminalInteractiveShell.banner1 = 'Python 2.6.2 (r262:71600, Jun  4 2010, 18:28:58) \nType "copyright", "credits" or "license" for more information.\n\nIPython 0.12 -- An enhanced Interactive Python.\n?         -> Introduction and overview of IPython\'s features.\n%quickref -> Quick reference.\nhelp      -> Python\'s own help system.\nobject?   -> Details about \'object\', use \'object??\' for extra details.\n'
 
-# 
+#
 # c.TerminalInteractiveShell.readline_parse_and_bind = ['tab: complete', '"\\C-l": clear-screen', 'set show-all-if-ambiguous on', '"\\C-o": tab-insert', '"\\C-r": reverse-search-history', '"\\C-s": forward-search-history', '"\\C-p": history-search-backward', '"\\C-n": history-search-forward', '"\\e[A": history-search-backward', '"\\e[B": history-search-forward', '"\\C-k": kill-line', '"\\C-u": unix-line-discard']
 
 # The part of the banner to be printed after the profile
 # c.TerminalInteractiveShell.banner2 = ''
 
-# 
+#
 # c.TerminalInteractiveShell.separate_out2 = ''
 
-# 
+#
 # c.TerminalInteractiveShell.wildcards_case_sensitive = True
 
-# 
+#
 # c.TerminalInteractiveShell.debug = False
 
 # Set to confirm when you try to exit IPython with an EOF (Control-D in Unix,
@@ -210,10 +221,10 @@ c.InteractiveShellApp.extensions = [
 # direct exit without any confirmation.
 # c.TerminalInteractiveShell.confirm_exit = True
 
-# 
+#
 # c.TerminalInteractiveShell.ipython_dir = ''
 
-# 
+#
 # c.TerminalInteractiveShell.readline_remove_delims = '-/~'
 
 # The name of the logfile to use.
@@ -226,7 +237,7 @@ logfile_fn = os.path.join(logfile_dir,
 with open(logfile_fn, 'w') as f:
     pass
 c.TerminalInteractiveShell.logfile = logfile_fn
-    
+
 
 # Start logging to the default log file.
 c.TerminalInteractiveShell.logstart = True
@@ -240,22 +251,22 @@ c.TerminalInteractiveShell.logstart = True
 # Save multi-line entries as one entry in readline history
 # c.TerminalInteractiveShell.multiline_history = True
 
-# 
+#
 # c.TerminalInteractiveShell.readline_use = True
 
 # Start logging to the given file in append mode.
 # c.TerminalInteractiveShell.logappend = ''
 
-# 
+#
 # c.TerminalInteractiveShell.xmode = 'Context'
 
-# 
+#
 # c.TerminalInteractiveShell.quiet = False
 
 # Enable auto setting the terminal title.
 # c.TerminalInteractiveShell.term_title = False
 
-# 
+#
 # c.TerminalInteractiveShell.object_info_string_level = 0
 
 # Deprecated, use PromptManager.out_template
@@ -290,7 +301,7 @@ c.TerminalInteractiveShell.logstart = True
 # Input prompt.  '\#' will be transformed to the prompt number
 # c.PromptManager.in_template = 'In [\\#]: '
 
-# 
+#
 # c.PromptManager.color_scheme = 'Linux'
 
 #------------------------------------------------------------------------------
@@ -298,10 +309,10 @@ c.TerminalInteractiveShell.logstart = True
 #------------------------------------------------------------------------------
 
 # An object to manage the profile directory and its resources.
-# 
+#
 # The profile directory is used by all IPython applications, to manage
 # configuration, logging and security.
-# 
+#
 # This object knows how to find, create and manage these directories. This
 # should be used by any code that wants to handle profiles.
 
@@ -314,12 +325,12 @@ c.TerminalInteractiveShell.logstart = True
 #------------------------------------------------------------------------------
 
 # The default pretty-printer.
-# 
+#
 # This uses :mod:`IPython.external.pretty` to compute the format data of the
 # object. If the object cannot be pretty printed, :func:`repr` is used. See the
 # documentation of :mod:`IPython.external.pretty` for details on how to write
 # pretty printers.  Here is a simple example::
-# 
+#
 #     def dtype_pprinter(obj, p, cycle):
 #         if cycle:
 #             return p.text('dtype(...)')
@@ -337,28 +348,28 @@ c.TerminalInteractiveShell.logstart = True
 
 # PlainTextFormatter will inherit config from: BaseFormatter
 
-# 
+#
 # c.PlainTextFormatter.type_printers = {}
 
-# 
+#
 # c.PlainTextFormatter.newline = '\n'
 
-# 
+#
 # c.PlainTextFormatter.float_precision = ''
 
-# 
+#
 # c.PlainTextFormatter.verbose = False
 
-# 
+#
 # c.PlainTextFormatter.deferred_printers = {}
 
-# 
+#
 # c.PlainTextFormatter.pprint = True
 
-# 
+#
 # c.PlainTextFormatter.max_width = 79
 
-# 
+#
 # c.PlainTextFormatter.singleton_printers = {}
 
 #------------------------------------------------------------------------------
@@ -370,24 +381,24 @@ c.TerminalInteractiveShell.logstart = True
 # IPCompleter will inherit config from: Completer
 
 # Instruct the completer to omit private method names
-# 
+#
 # Specifically, when completing on ``object.<tab>``.
-# 
+#
 # When 2 [default]: all names that start with '_' will be excluded.
-# 
+#
 # When 1: all 'magic' names (``__foo__``) will be excluded.
-# 
+#
 # When 0: nothing will be excluded.
 # c.IPCompleter.omit__names = 2
 
 # Whether to merge completion results into a single list
-# 
+#
 # If False, only the completion results from the first non-empty completer will
 # be returned.
 # c.IPCompleter.merge_completions = True
 
 # Activate greedy completion
-# 
+#
 # This will enable completion on elements of lists, results of function calls,
 # etc., but can be unsafe because the code is actually evaluated on TAB.
 # c.IPCompleter.greedy = False

--- a/ipython_config.py
+++ b/ipython_config.py
@@ -63,7 +63,7 @@ c = get_config()
 
 # Pre-load matplotlib and numpy for interactive use, selecting a particular
 # matplotlib backend and loop integration.
-# c.TerminalIPythonApp.pylab = 'qt5'
+# c.TerminalIPythonApp.pylab = 'None'
 
 # Suppress warning messages about legacy config files
 # hilariously, this setting now itself causes a warning!
@@ -90,8 +90,6 @@ c.TerminalIPythonApp.display_banner = False
 
 # Start IPython quickly by skipping the loading of config files.
 # c.TerminalIPythonApp.quick = False
-
-
 
 # A list of dotted module names of IPython extensions to load.
 


### PR DESCRIPTION
Included a try and catch block inside the file 'ipython_config.py' to suppress the stacktrace from appearing inside an Ipython terminal in the scenario where certain custom imports such as line_profiler and cython are not inside the namespace of ipython_config, when an ipython terminal is first loaded. I have also made minor changes to the generate_failover_imports file - including the use of a suppress warnings clause instead of a try/catch clause to catch the exceptions generated for ModuleNotFoundError and ImportError. Should conform to pep8 standards.